### PR TITLE
passing indices instead of copying data-subsets

### DIFF
--- a/R-package/inst/include/tree.hpp
+++ b/R-package/inst/include/tree.hpp
@@ -128,7 +128,11 @@ void GBTREE::train(Tvec<double> &g, Tvec<double> &h, Tmat<double> &X, Tmat<doubl
         root = root->createLeaf(-G/H, -G*G/(2*H*n), local_optimism, local_optimism, n, n, n);
     }
     
-    root->split_node(g, h, X, cir_sim, root, n, 0.0, greedy_complexities, learning_rate, 0, maxDepth);
+    // Root-node indices
+    Tvec<int> ind(n);
+    std::iota(ind.data(), ind.data()+ind.size(), 0);
+    
+    root->split_node(g, h, ind, X, cir_sim, root, n, 0.0, greedy_complexities, learning_rate, 0, maxDepth);
     
 }
 


### PR DESCRIPTION
Old: design matrix `X` and differentials `g` and `h` are copied and subsets are created in memory.
New: Keep track of indices of node, and split this instead