### PR TITLE
Avoid seeking by failing tree parsing when the first node parsing fails

### DIFF
--- a/R-package/inst/include/node.hpp
+++ b/R-package/inst/include/node.hpp
@@ -55,7 +55,7 @@ public:
     void print_child_branches_2(const std::string& prefix, const node* nptr, bool isLeft);
     
     void serialize(node* nptr, std::ofstream& f);
-    bool deSerialize(node *nptr, std::ifstream& f, int& lineNum);
+    bool deSerialize(node *nptr, std::ifstream& f);
 };
 
 /*
@@ -105,22 +105,15 @@ void node::serialize(node* nptr, std::ofstream& f)
     
 }
 
-bool node::deSerialize(node *nptr, std::ifstream& f, int& lineNum)
+bool node::deSerialize(node *nptr, std::ifstream& f)
 {
     
     int MARKER = -1;
-    
-    // Start at beginning
-    f.seekg(0, std::ios::beg);
-    
-    // Run until line lineNum is found
+
     std::string stemp;
-    for(int i=0; i<= lineNum; i++)
-    {
-        if(!std::getline(f,stemp)){
-            nptr = NULL;
-            return false;
-        }
+    if(!std::getline(f,stemp)){
+        nptr = NULL;
+        return false;
     }
     
     // Check stemp for MARKER
@@ -129,8 +122,6 @@ bool node::deSerialize(node *nptr, std::ifstream& f, int& lineNum)
     istemp >> val;
     if(val == MARKER){
         nptr = NULL;
-        // Increment lineNum
-        lineNum++;
         return false;
     }
     
@@ -139,16 +130,13 @@ bool node::deSerialize(node *nptr, std::ifstream& f, int& lineNum)
     istemp >> nptr->obs_in_node >> nptr->split_value >> nptr->node_prediction >>
         nptr->node_tr_loss >> nptr->prob_node >> nptr->local_optimism >>
         nptr->expected_max_S >> nptr->CRt >> nptr->p_split_CRt;
-
-    // Increment lineNum
-    lineNum++;
     
     // Node check value
     bool node_success = false;
     
     // Left node
     node* new_left = new node;
-    node_success = deSerialize(new_left, f, lineNum);
+    node_success = deSerialize(new_left, f);
     if(node_success)
     {
         nptr->left = new_left;
@@ -159,7 +147,7 @@ bool node::deSerialize(node *nptr, std::ifstream& f, int& lineNum)
     // Right node
     node_success = false;
     node* new_right = new node;
-    node_success = deSerialize(new_right, f, lineNum);
+    node_success = deSerialize(new_right, f);
     if(node_success)
     {
         nptr->right = new_right;

--- a/R-package/inst/include/tree.hpp
+++ b/R-package/inst/include/tree.hpp
@@ -31,7 +31,7 @@ public:
     int getNumLeaves();
     void print_tree(int type);
     void serialize(GBTREE* tptr, std::ofstream& f);
-    bool deSerialize(GBTREE* tptr,  std::ifstream& f, int& lineNum);
+    bool deSerialize(GBTREE* tptr,  std::ifstream& f);
     void importance(Tvec<double> &importance_vector, double learning_rate);
     
 };
@@ -55,38 +55,17 @@ void GBTREE::serialize(GBTREE *tptr, std::ofstream& f)
     serialize(tptr->next_tree, f);
 }
 
-bool GBTREE::deSerialize(GBTREE *tptr, std::ifstream& f, int& lineNum)
+bool GBTREE::deSerialize(GBTREE *tptr, std::ifstream& f)
 {
-    
-    int MARKER = -1;
-    
-    // Start at beginning
-    f.seekg(0, std::ios::beg);
-    
-    // Run until line lineNum is found
-    std::string stemp;
-    for(int i=0; i<= lineNum; i++)
-    {
-        if(!std::getline(f,stemp)){
-            tptr = NULL;
-            return false;
-        }
-    }
-    
-    // Check stemp for MARKER
-    std::istringstream istemp(stemp);
-    int val;
-    istemp >> val;
-    if(val == MARKER){ 
+    tptr->root = new node;
+    const bool success = tptr->root->deSerialize(tptr->root, f);
+    if (!success) {
         tptr = NULL;
         return false;
     }
 
-    // If not MARKER, deserialize root node (unincremented lineNum)
-    tptr->root = new node;
-    tptr->root->deSerialize(tptr->root, f, lineNum); // lineNum passed by reference and incremented
     GBTREE* new_tree = new GBTREE;
-    bool new_tree_exist = deSerialize(new_tree, f, lineNum);
+    bool new_tree_exist = deSerialize(new_tree, f);
     if(new_tree_exist)
     {
         tptr->next_tree = new_tree;

--- a/R-package/src/agtboost.cpp
+++ b/R-package/src/agtboost.cpp
@@ -7,8 +7,6 @@
 
 #include "agtboost.hpp"
 
-
-
 // ---------------- ENSEMBLE ----------------
 ENSEMBLE::ENSEMBLE(){
     this->first_tree = NULL;
@@ -68,12 +66,10 @@ void ENSEMBLE::serialize(ENSEMBLE *eptr, std::ofstream& f)
     
     eptr->first_tree->serialize(eptr->first_tree, f);
     f.close();
-    
 }
 
 void ENSEMBLE::deSerialize(ENSEMBLE *eptr, std::ifstream& f)
 {
-    
     // Check stream
     std::streampos oldpos = f.tellg();
     int val;
@@ -85,13 +81,10 @@ void ENSEMBLE::deSerialize(ENSEMBLE *eptr, std::ifstream& f)
     
     // Read from stream
     f >> eptr->nrounds >> eptr->learning_rate >> eptr->extra_param >>
-        eptr->initialPred >> eptr->initial_score >> eptr->loss_function;
-    
-    // Start recurrence
-    int lineNum = 6;
+        eptr->initialPred >> eptr->initial_score >> eptr->loss_function >> std::ws;
+
     eptr->first_tree = new GBTREE;
-    eptr->first_tree->deSerialize(eptr->first_tree, f, lineNum);
-    
+    eptr->first_tree->deSerialize(eptr->first_tree, f);
 }
 
 void ENSEMBLE::save_model(std::string filepath)
@@ -101,6 +94,7 @@ void ENSEMBLE::save_model(std::string filepath)
     this->serialize(this, f);
     f.close();
 }
+
 void ENSEMBLE::load_model(std::string filepath)
 {
     std::ifstream f;
@@ -108,7 +102,6 @@ void ENSEMBLE::load_model(std::string filepath)
     this->deSerialize(this, f);
     f.close();
 }
-
  
 double ENSEMBLE::initial_prediction(Tvec<double> &y, std::string loss_function, Tvec<double> &w){
     


### PR DESCRIPTION
Hej @Blunde1! 

Some days ago I ended up optimizing the load operation and I thought it'd be a good idea to contribute this upstream. For the models I have tested the loading time improved by roughly 1000x.

Essentially I try to avoid all seeking around the file and just read straight from it. The one case that violated this principle before was when the code checked if a tree was empty. Instead I now rely on the first node failing with an error and exit when that happens.

cc @martgnz