### PR TITLE
Optimal initial prediction

### DIFF
--- a/R-package/NEWS.md
+++ b/R-package/NEWS.md
@@ -20,3 +20,4 @@ agtboost 0.9.2 (2021-11-01)
 - Obtain XGBoost and LightGBM hyperparameters from gbt.complexity().
 - Include attribute "offset" in gbt.train() and predict().
 - Throw error when gb-loss-approximation deviates from true loss. Suggest lower learning_rate.
+- Solves $\arg\min_\eta \sum_i l(y_i, g^{-1}(offset_i+\eta))$ numerically instead of simple average to obtain initial prediction

--- a/R-package/inst/include/agtboost.hpp
+++ b/R-package/inst/include/agtboost.hpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <functional>
 
 // Internal
 #include "cir.hpp"
@@ -21,6 +22,7 @@
 #include "optimization.hpp"
 #include "loss_functions.hpp"
 #include "gbt_count_auto.hpp"
+#include "initial_prediction.hpp"
 
 
 #endif // __GMGTB_HPP_INCLUDED__

--- a/R-package/inst/include/ensemble.hpp
+++ b/R-package/inst/include/ensemble.hpp
@@ -58,5 +58,4 @@ public:
 };
 
 
-
 #endif

--- a/R-package/inst/include/ensemble.hpp
+++ b/R-package/inst/include/ensemble.hpp
@@ -36,6 +36,8 @@ public:
     double loss(Tvec<double> &y, Tvec<double> &pred, Tvec<double> &w);
     Tvec<double> dloss(Tvec<double> &y, Tvec<double> &pred);
     Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred);
+    double link_function(double pred_observed);
+    double inverse_link_function(double pred);
     
     double initial_prediction(Tvec<double> &y, std::string loss_function, Tvec<double> &w);
     void train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities,

--- a/R-package/inst/include/ensemble.hpp
+++ b/R-package/inst/include/ensemble.hpp
@@ -33,6 +33,10 @@ public:
     double get_extra_param();
     std::string get_loss_function();
     
+    double loss(Tvec<double> &y, Tvec<double> &pred, Tvec<double> &w);
+    Tvec<double> dloss(Tvec<double> &y, Tvec<double> &pred);
+    Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred);
+    
     double initial_prediction(Tvec<double> &y, std::string loss_function, Tvec<double> &w);
     void train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities,
                bool force_continued_learning, Tvec<double> &w, Tvec<double> &offset,

--- a/R-package/inst/include/initial_prediction.hpp
+++ b/R-package/inst/include/initial_prediction.hpp
@@ -1,0 +1,56 @@
+// initial_prediction.hpp
+
+#ifndef __INITIAL_PREDICTION_HPP_INCLUDED__
+#define __INITIAL_PREDICTION_HPP_INCLUDED__
+
+
+#include "external_rcpp.hpp"
+
+
+double learn_initial_prediction(
+        Tvec<double>& y, 
+        Tvec<double>& offset,
+        std::function<Tvec<double> (Tvec<double>&,Tvec<double>&)> dloss,
+        std::function<Tvec<double> (Tvec<double>&,Tvec<double>&)> ddloss,
+        std::function<double (double)> link_function,
+        std::function<double (double)> inverse_link_function,
+        int verbose
+    ){
+    // Newton opt settings
+    double tolerance = 1E-9;
+    double step_length = 0.2;
+    double step=0.0;
+    int niter = 50; // Max iterations
+    // Data specific settings
+    int n = y.size();
+    double y_average = y.sum() / n;
+    double initial_prediction = link_function(y_average);
+    Tvec<double> pred = offset.array() + initial_prediction;
+    // Iterate until optimal starting point found
+    for(int i=0; i<niter; i++){
+        // Gradient descent
+        step = - step_length * dloss(y, pred).sum() / ddloss(y, pred).sum();
+        initial_prediction += step;
+        pred = pred.array() + step;
+        // Check precision
+        if(std::abs(step) <= tolerance){
+            break;
+        }
+    }
+    // Verbose?
+    if(verbose>0){
+        Rcpp::Rcout << 
+            std::setprecision(4) <<
+            "Initial prediction and raw-prediction estimated to :" << 
+                inverse_link_function(initial_prediction) <<
+                    " and " <<
+                initial_prediction << 
+                    " respectively" <<
+                        std::endl;
+    }
+    // Retun optimal starting point
+    return initial_prediction;
+}
+
+
+#endif

--- a/R-package/inst/include/loss_functions.hpp
+++ b/R-package/inst/include/loss_functions.hpp
@@ -7,6 +7,48 @@
 
 // ----------- LOSS --------------
 namespace loss_functions {
+
+
+    double link_function(double pred_observed, std::string loss_function){
+        // Returns g(mu)
+        double pred_transformed=0.0;
+        if(loss_function=="mse"){
+            pred_transformed = pred_observed;
+        }else if(loss_function=="logloss"){
+            pred_transformed = log(pred_observed) - log(1 - pred_observed);
+        }else if(loss_function=="poisson"){
+            pred_transformed = log(pred_observed);
+        }else if(loss_function=="gamma::neginv"){
+            pred_transformed = - 1.0 / pred_observed;
+        }else if(loss_function=="gamma::log"){
+            pred_transformed = log(pred_observed);
+        }else if(loss_function=="negbinom"){
+            pred_transformed = log(pred_observed);
+        }
+        return pred_transformed;
+    }
+
+
+    double inverse_link_function(double pred_transformed, std::string loss_function){
+        // Returns g^{-1}(pred)
+        double pred_observed = 0.0;
+        if(loss_function=="mse"){
+            pred_observed = pred_transformed;
+        }else if(loss_function=="logloss"){
+            pred_observed = 1.0 / (1.0+exp(-pred_transformed));
+        }else if(loss_function=="poisson"){
+            pred_observed = exp(pred_transformed);
+        }else if(loss_function=="gamma::neginv"){
+            pred_observed = -1.0 / pred_transformed;;
+        }else if(loss_function=="gamma::log"){
+            pred_observed = exp(pred_transformed);
+        }else if(loss_function=="negbinom"){
+            pred_observed = exp(pred_transformed);
+        }
+        return pred_observed;
+    }
+
+
     double loss(
             Tvec<double> &y, 
             Tvec<double> &pred, 

--- a/R-package/inst/include/loss_functions.hpp
+++ b/R-package/inst/include/loss_functions.hpp
@@ -6,7 +6,14 @@
 #include "external_rcpp.hpp"
 
 // ----------- LOSS --------------
-double loss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, Tvec<double> &w, ENSEMBLE* ens_ptr){
+double loss(
+        Tvec<double> &y, 
+        Tvec<double> &pred, 
+        std::string loss_type, 
+        Tvec<double> &w, 
+        double extra_param=0.0
+){
+    // Evaluates the loss function at pred
     int n = y.size();
     double res = 0;
     
@@ -38,7 +45,7 @@ double loss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, Tvec<dou
             res += y[i]*w[i]*exp(-pred[i]) + pred[i];
         }
     }else if(loss_type=="negbinom"){
-        double dispersion = ens_ptr -> extra_param;
+        double dispersion = extra_param;
         for(int i=0; i<n; i++){
             // log-link, mu=exp(pred[i])
             res += -y[i]*pred[i] + (y[i]*dispersion)*log(1.0+exp(pred[i])/dispersion); // Keep only relevant part
@@ -75,8 +82,13 @@ double loss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, Tvec<dou
 }
 
 
-Tvec<double> dloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, ENSEMBLE* ens_ptr){
-    
+Tvec<double> dloss(
+        Tvec<double> &y, 
+        Tvec<double> &pred, 
+        std::string loss_type, 
+        double extra_param=0.0
+){
+    // Returns the first order derivative of the loss function at pred
     int n = y.size();
     Tvec<double> g(n);
     
@@ -107,7 +119,7 @@ Tvec<double> dloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, E
         }
     }else if(loss_type == "negbinom"){
         // NEGATIVE BINOMIAL, LOG LINK
-        double dispersion = ens_ptr->extra_param;
+        double dispersion = extra_param;
         for(int i=0; i<n; i++){
             g[i] = -y[i] + (y[i]+dispersion)*exp(pred[i]) / (dispersion + exp(pred[i]));
         }
@@ -143,7 +155,13 @@ Tvec<double> dloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, E
 }
 
 
-Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, ENSEMBLE* ens_ptr){
+Tvec<double> ddloss(
+        Tvec<double> &y, 
+        Tvec<double> &pred, 
+        std::string loss_type, 
+        double extra_param=0.0
+){
+    // Returns the second order derivative of the loss function at pred
     int n = y.size();
     Tvec<double> h(n);
     
@@ -174,7 +192,7 @@ Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, 
         }
     }else if( loss_type == "negbinom" ){
         // NEGATIVE BINOMIAL, LOG LINK
-        double dispersion = ens_ptr->extra_param;
+        double dispersion = extra_param;
         for(int i=0; i<n; i++){
             h[i] = (y[i]+dispersion)*dispersion*exp(pred[i]) / 
                 ( (dispersion + exp(pred[i]))*(dispersion + exp(pred[i])) );
@@ -216,5 +234,6 @@ Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, 
     
     return h;    
 }
+
 
 #endif

--- a/R-package/inst/include/loss_functions.hpp
+++ b/R-package/inst/include/loss_functions.hpp
@@ -6,233 +6,235 @@
 #include "external_rcpp.hpp"
 
 // ----------- LOSS --------------
-double loss(
-        Tvec<double> &y, 
-        Tvec<double> &pred, 
-        std::string loss_type, 
-        Tvec<double> &w, 
-        double extra_param=0.0
-){
-    // Evaluates the loss function at pred
-    int n = y.size();
-    double res = 0;
-    
-    if(loss_type=="mse"){
-        // MSE
-        for(int i=0; i<n; i++){
-            res += pow(y[i]*w[i]-pred[i],2);
-        }
+namespace loss_functions {
+    double loss(
+            Tvec<double> &y, 
+            Tvec<double> &pred, 
+            std::string loss_type, 
+            Tvec<double> &w, 
+            double extra_param=0.0
+    ){
+        // Evaluates the loss function at pred
+        int n = y.size();
+        double res = 0;
         
-    }else if(loss_type=="logloss"){
-        // LOGLOSS
-        for(int i=0; i<n; i++){
-            res += y[i]*w[i]*log(1.0+exp(-pred[i])) + (1.0-y[i]*w[i])*log(1.0 + exp(pred[i]));
+        if(loss_type=="mse"){
+            // MSE
+            for(int i=0; i<n; i++){
+                res += pow(y[i]*w[i]-pred[i],2);
+            }
+            
+        }else if(loss_type=="logloss"){
+            // LOGLOSS
+            for(int i=0; i<n; i++){
+                res += y[i]*w[i]*log(1.0+exp(-pred[i])) + (1.0-y[i]*w[i])*log(1.0 + exp(pred[i]));
+            }
+        }else if(loss_type=="poisson"){
+            // POISSON
+            for(int i=0; i<n; i++){
+                res += exp(pred[i]) - y[i]*w[i]*pred[i]; // skip normalizing factor log(y!)
+            }
+        }else if(loss_type=="gamma::neginv"){
+            // GAMMA::NEGINV
+            // shape=1, only relevant part of negative log-likelihood
+            for(int i=0; i<n; i++){
+                res += -y[i]*w[i]*pred[i] - log(-pred[i]);
+            }
+        }else if(loss_type=="gamma::log"){
+            // GAMMA::LOG
+            for(int i=0; i<n; i++){
+                res += y[i]*w[i]*exp(-pred[i]) + pred[i];
+            }
+        }else if(loss_type=="negbinom"){
+            double dispersion = extra_param;
+            for(int i=0; i<n; i++){
+                // log-link, mu=exp(pred[i])
+                res += -y[i]*pred[i] + (y[i]*dispersion)*log(1.0+exp(pred[i])/dispersion); // Keep only relevant part
+            }
         }
-    }else if(loss_type=="poisson"){
-        // POISSON
-        for(int i=0; i<n; i++){
-            res += exp(pred[i]) - y[i]*w[i]*pred[i]; // skip normalizing factor log(y!)
-        }
-    }else if(loss_type=="gamma::neginv"){
-        // GAMMA::NEGINV
-        // shape=1, only relevant part of negative log-likelihood
-        for(int i=0; i<n; i++){
-            res += -y[i]*w[i]*pred[i] - log(-pred[i]);
-        }
-    }else if(loss_type=="gamma::log"){
-        // GAMMA::LOG
-        for(int i=0; i<n; i++){
-            res += y[i]*w[i]*exp(-pred[i]) + pred[i];
-        }
-    }else if(loss_type=="negbinom"){
-        double dispersion = extra_param;
-        for(int i=0; i<n; i++){
-            // log-link, mu=exp(pred[i])
-            res += -y[i]*pred[i] + (y[i]*dispersion)*log(1.0+exp(pred[i])/dispersion); // Keep only relevant part
-        }
+        // else if(loss_type=="poisson::zip"){
+        //     // POISSON COND Y>0, LOG LINK
+        //     for(int i=0; i<n; i++){
+        //         res += exp(pred[i]) - y[i]*pred[i] + log(1.0-exp(-exp(pred[i]))); // Last is conditional p(y>0)
+        //     }
+        // }else if(loss_type=="zero_inflation"){
+        //     // ZERO-INFLATION PROBABILITY MIX
+        //     Tvec<double> lprob_weights = ens_ptr->param["log_prob_weights"];
+        //     for(int i=0; i<n; i++){
+        //         if(y[i] > 0){
+        //             // avoid comparing equality to zero...
+        //             res += pred[i] + log(1.0+exp(-pred[i])) - lprob_weights[i]; // Weight is log probability weight!!
+        //         }else{
+        //             // get y[i] == 0
+        //             res += -log(1.0/(1.0+exp(-pred[i])) + (1.0 - 1.0/(1.0+exp(-pred[i])))*exp(lprob_weights[i]) );
+        //         }
+        //     }
+        // }else if(loss_type=="negbinom::zinb"){
+        //     // NEGBINOM COND Y>0, LOG LINK
+        //     double dispersion = ens_ptr -> extra_param;
+        //     for(int i=0; i<n; i++){
+        //         res += -y[i]*pred[i] + (y[i]*dispersion)*log(1.0+exp(pred[i])/dispersion) + 
+        //             log(1.0-(exp(-dispersion*log(1.0+exp(pred[i])/dispersion)))); // Last is conditional p(y>0)
+        //     }
+        // }
+        
+        return res/n;
+        
     }
-    // else if(loss_type=="poisson::zip"){
-    //     // POISSON COND Y>0, LOG LINK
-    //     for(int i=0; i<n; i++){
-    //         res += exp(pred[i]) - y[i]*pred[i] + log(1.0-exp(-exp(pred[i]))); // Last is conditional p(y>0)
-    //     }
-    // }else if(loss_type=="zero_inflation"){
-    //     // ZERO-INFLATION PROBABILITY MIX
-    //     Tvec<double> lprob_weights = ens_ptr->param["log_prob_weights"];
-    //     for(int i=0; i<n; i++){
-    //         if(y[i] > 0){
-    //             // avoid comparing equality to zero...
-    //             res += pred[i] + log(1.0+exp(-pred[i])) - lprob_weights[i]; // Weight is log probability weight!!
-    //         }else{
-    //             // get y[i] == 0
-    //             res += -log(1.0/(1.0+exp(-pred[i])) + (1.0 - 1.0/(1.0+exp(-pred[i])))*exp(lprob_weights[i]) );
-    //         }
-    //     }
-    // }else if(loss_type=="negbinom::zinb"){
-    //     // NEGBINOM COND Y>0, LOG LINK
-    //     double dispersion = ens_ptr -> extra_param;
-    //     for(int i=0; i<n; i++){
-    //         res += -y[i]*pred[i] + (y[i]*dispersion)*log(1.0+exp(pred[i])/dispersion) + 
-    //             log(1.0-(exp(-dispersion*log(1.0+exp(pred[i])/dispersion)))); // Last is conditional p(y>0)
-    //     }
-    // }
     
-    return res/n;
     
-}
-
-
-Tvec<double> dloss(
-        Tvec<double> &y, 
-        Tvec<double> &pred, 
-        std::string loss_type, 
-        double extra_param=0.0
-){
-    // Returns the first order derivative of the loss function at pred
-    int n = y.size();
-    Tvec<double> g(n);
-    
-    if(loss_type == "mse"){
-        // MSE
-        for(int i=0; i<n; i++){
-            g[i] = -2*(y[i]-pred[i]);
+    Tvec<double> dloss(
+            Tvec<double> &y, 
+            Tvec<double> &pred, 
+            std::string loss_type, 
+            double extra_param=0.0
+    ){
+        // Returns the first order derivative of the loss function at pred
+        int n = y.size();
+        Tvec<double> g(n);
+        
+        if(loss_type == "mse"){
+            // MSE
+            for(int i=0; i<n; i++){
+                g[i] = -2*(y[i]-pred[i]);
+            }
+        }else if(loss_type == "logloss"){
+            // LOGLOSS
+            for(int i=0; i<n; i++){
+                g[i] = ( exp(pred[i]) * (1.0-y[i]) - y[i] ) / ( 1.0 + exp(pred[i]) );
+            }
+        }else if(loss_type == "poisson"){
+            // POISSON REG
+            for(int i=0; i<n; i++){
+                g[i] = exp(pred[i]) - y[i];
+            }
+        }else if(loss_type == "gamma::neginv"){
+            // GAMMA::NEGINV
+            for(int i=0; i<n; i++){
+                g[i] = -(y[i]+1.0/pred[i]);
+            }
+        }else if(loss_type == "gamma::log"){
+            // GAMMA::LOG
+            for(int i=0; i<n; i++){
+                g[i] = -y[i]*exp(-pred[i]) + 1.0;
+            }
+        }else if(loss_type == "negbinom"){
+            // NEGATIVE BINOMIAL, LOG LINK
+            double dispersion = extra_param;
+            for(int i=0; i<n; i++){
+                g[i] = -y[i] + (y[i]+dispersion)*exp(pred[i]) / (dispersion + exp(pred[i]));
+            }
         }
-    }else if(loss_type == "logloss"){
-        // LOGLOSS
-        for(int i=0; i<n; i++){
-            g[i] = ( exp(pred[i]) * (1.0-y[i]) - y[i] ) / ( 1.0 + exp(pred[i]) );
-        }
-    }else if(loss_type == "poisson"){
-        // POISSON REG
-        for(int i=0; i<n; i++){
-            g[i] = exp(pred[i]) - y[i];
-        }
-    }else if(loss_type == "gamma::neginv"){
-        // GAMMA::NEGINV
-        for(int i=0; i<n; i++){
-            g[i] = -(y[i]+1.0/pred[i]);
-        }
-    }else if(loss_type == "gamma::log"){
-        // GAMMA::LOG
-        for(int i=0; i<n; i++){
-            g[i] = -y[i]*exp(-pred[i]) + 1.0;
-        }
-    }else if(loss_type == "negbinom"){
-        // NEGATIVE BINOMIAL, LOG LINK
-        double dispersion = extra_param;
-        for(int i=0; i<n; i++){
-            g[i] = -y[i] + (y[i]+dispersion)*exp(pred[i]) / (dispersion + exp(pred[i]));
-        }
+        // else if(loss_type == "poisson::zip"){
+        //     // POISSON COND Y>0, LOG LINK
+        //     for(int i=0; i<n; i++){
+        //         g[i] = exp(pred[i]) - y[i] + exp(pred[i])/(exp(exp(pred[i]))-1.0);
+        //     }
+        // }else if(loss_type=="zero_inflation"){
+        //     // ZERO-INFLATION PROBABILITY MIX
+        //     Tvec<double> lprob_weights = ens_ptr->param["log_prob_weights"];
+        //     for(int i=0; i<n; i++){
+        //         if(y[i] > 0){
+        //             // avoid comparing equality to zero...
+        //             g[i] = exp(pred[i]) / (exp(pred[i]) + 1.0);
+        //         }else{
+        //             // get y[i] == 0
+        //             g[i] = (exp(lprob_weights[i])-1.0)*exp(pred[i]) / ( (exp(pred[i])+1.0)*(exp(lprob_weights[i])+exp(pred[i])) );
+        //         }
+        //     }
+        // }else if(loss_type=="negbinom::zinb"){
+        //     // NEGBINOM COND Y>0, LOG LINK
+        //     double dispersion = ens_ptr -> extra_param;
+        //     for(int i=0; i<n; i++){
+        //         g[i] = -y[i] + (y[i]+dispersion)*exp(pred[i]) / (dispersion + exp(pred[i])) + 
+        //             dispersion*exp(pred[i]) / 
+        //             ( (dispersion+exp(pred[i]))*( exp(dispersion*(log(dispersion+exp(pred[i]))-log(dispersion))) -1.0 ));
+        //     }
+        // }
+        
+        return g;
     }
-    // else if(loss_type == "poisson::zip"){
-    //     // POISSON COND Y>0, LOG LINK
-    //     for(int i=0; i<n; i++){
-    //         g[i] = exp(pred[i]) - y[i] + exp(pred[i])/(exp(exp(pred[i]))-1.0);
-    //     }
-    // }else if(loss_type=="zero_inflation"){
-    //     // ZERO-INFLATION PROBABILITY MIX
-    //     Tvec<double> lprob_weights = ens_ptr->param["log_prob_weights"];
-    //     for(int i=0; i<n; i++){
-    //         if(y[i] > 0){
-    //             // avoid comparing equality to zero...
-    //             g[i] = exp(pred[i]) / (exp(pred[i]) + 1.0);
-    //         }else{
-    //             // get y[i] == 0
-    //             g[i] = (exp(lprob_weights[i])-1.0)*exp(pred[i]) / ( (exp(pred[i])+1.0)*(exp(lprob_weights[i])+exp(pred[i])) );
-    //         }
-    //     }
-    // }else if(loss_type=="negbinom::zinb"){
-    //     // NEGBINOM COND Y>0, LOG LINK
-    //     double dispersion = ens_ptr -> extra_param;
-    //     for(int i=0; i<n; i++){
-    //         g[i] = -y[i] + (y[i]+dispersion)*exp(pred[i]) / (dispersion + exp(pred[i])) + 
-    //             dispersion*exp(pred[i]) / 
-    //             ( (dispersion+exp(pred[i]))*( exp(dispersion*(log(dispersion+exp(pred[i]))-log(dispersion))) -1.0 ));
-    //     }
-    // }
     
-    return g;
-}
-
-
-Tvec<double> ddloss(
-        Tvec<double> &y, 
-        Tvec<double> &pred, 
-        std::string loss_type, 
-        double extra_param=0.0
-){
-    // Returns the second order derivative of the loss function at pred
-    int n = y.size();
-    Tvec<double> h(n);
     
-    if( loss_type == "mse" ){
-        // MSE
-        for(int i=0; i<n; i++){
-            h[i] = 2.0;
+    Tvec<double> ddloss(
+            Tvec<double> &y, 
+            Tvec<double> &pred, 
+            std::string loss_type, 
+            double extra_param=0.0
+    ){
+        // Returns the second order derivative of the loss function at pred
+        int n = y.size();
+        Tvec<double> h(n);
+        
+        if( loss_type == "mse" ){
+            // MSE
+            for(int i=0; i<n; i++){
+                h[i] = 2.0;
+            }
+        }else if(loss_type == "logloss"){
+            // LOGLOSS
+            for(int i=0; i<n; i++){
+                h[i] = exp(pred[i]) / ( (exp(pred[i])+1.0)*(exp(pred[i])+1.0) ) ;
+            }
+        }else if(loss_type == "poisson"){
+            // POISSON REG
+            for(int i=0; i<n; i++){
+                h[i] = exp(pred[i]);
+            }
+        }else if(loss_type == "gamma::neginv"){
+            // GAMMA::NEGINV
+            for(int i=0; i<n; i++){
+                h[i] = 1.0/(pred[i]*pred[i]);
+            }
+        }else if(loss_type == "gamma::log"){
+            // GAMMA::LOG
+            for(int i=0; i<n; i++){
+                h[i] = y[i] * exp(-pred[i]);
+            }
+        }else if( loss_type == "negbinom" ){
+            // NEGATIVE BINOMIAL, LOG LINK
+            double dispersion = extra_param;
+            for(int i=0; i<n; i++){
+                h[i] = (y[i]+dispersion)*dispersion*exp(pred[i]) / 
+                    ( (dispersion + exp(pred[i]))*(dispersion + exp(pred[i])) );
+            }
         }
-    }else if(loss_type == "logloss"){
-        // LOGLOSS
-        for(int i=0; i<n; i++){
-            h[i] = exp(pred[i]) / ( (exp(pred[i])+1.0)*(exp(pred[i])+1.0) ) ;
-        }
-    }else if(loss_type == "poisson"){
-        // POISSON REG
-        for(int i=0; i<n; i++){
-            h[i] = exp(pred[i]);
-        }
-    }else if(loss_type == "gamma::neginv"){
-        // GAMMA::NEGINV
-        for(int i=0; i<n; i++){
-            h[i] = 1.0/(pred[i]*pred[i]);
-        }
-    }else if(loss_type == "gamma::log"){
-        // GAMMA::LOG
-        for(int i=0; i<n; i++){
-            h[i] = y[i] * exp(-pred[i]);
-        }
-    }else if( loss_type == "negbinom" ){
-        // NEGATIVE BINOMIAL, LOG LINK
-        double dispersion = extra_param;
-        for(int i=0; i<n; i++){
-            h[i] = (y[i]+dispersion)*dispersion*exp(pred[i]) / 
-                ( (dispersion + exp(pred[i]))*(dispersion + exp(pred[i])) );
-        }
+        // else if(loss_type == "poisson::zip"){
+        //     // POISSON COND Y>0, LOG LINK
+        //     for(int i=0; i<n; i++){
+        //         h[i] = exp(pred[i]) + 
+        //             exp(pred[i])*(exp(exp(pred[i]))-exp(pred[i]+exp(pred[i]))-1.0) / 
+        //             ( (exp(exp(pred[i]))-1.0)*(exp(exp(pred[i]))-1.0) );
+        //     }
+        // }else if(loss_type=="zero_inflation"){
+        //     // ZERO-INFLATION PROBABILITY MIX
+        //     Tvec<double> lprob_weights = ens_ptr->param["log_prob_weights"];
+        //     for(int i=0; i<n; i++){
+        //         if(y[i] > 0){
+        //             // avoid comparing equality to zero...
+        //             h[i] = exp(pred[i]) / ((exp(pred[i]) + 1.0)*(exp(pred[i]) + 1.0));
+        //         }else{
+        //             // get y[i] == 0
+        //             h[i] = -(exp(lprob_weights[i])-1.0)*exp(pred[i])*(exp(2.0*pred[i])-exp(lprob_weights[i])) / 
+        //                 ( (exp(pred[i])+1.0)*(exp(pred[i])+1.0)*(exp(lprob_weights[i])+exp(pred[i]))*(exp(lprob_weights[i])+exp(pred[i])) );
+        //         }
+        //     }
+        // }else if(loss_type=="negbinom::zinb"){
+        //     // NEGBINOM COND Y>0, LOG LINK
+        //     double dispersion = ens_ptr -> extra_param;
+        //     for(int i=0; i<n; i++){
+        //         h[i] = (y[i]+dispersion)*dispersion*exp(pred[i]) / 
+        //             ( (dispersion + exp(pred[i]))*(dispersion + exp(pred[i])) ) - 
+        //             // d^2/dx^2 log(p(y>0))
+        //             -dispersion*dispersion*exp(pred[i])*
+        //             ((exp(pred[i])-1.0)*exp(dispersion*(log(dispersion+exp(pred[i]))-log(dispersion))) +1.0 ) / 
+        //             (exp(2.0*log(dispersion+exp(pred[i]))) * 
+        //              pow(exp(dispersion*(log(dispersion+exp(pred[i]))-log(dispersion))) - 1.0, 2.0 )  );
+        //     }
+        // }
+        
+        return h;    
     }
-    // else if(loss_type == "poisson::zip"){
-    //     // POISSON COND Y>0, LOG LINK
-    //     for(int i=0; i<n; i++){
-    //         h[i] = exp(pred[i]) + 
-    //             exp(pred[i])*(exp(exp(pred[i]))-exp(pred[i]+exp(pred[i]))-1.0) / 
-    //             ( (exp(exp(pred[i]))-1.0)*(exp(exp(pred[i]))-1.0) );
-    //     }
-    // }else if(loss_type=="zero_inflation"){
-    //     // ZERO-INFLATION PROBABILITY MIX
-    //     Tvec<double> lprob_weights = ens_ptr->param["log_prob_weights"];
-    //     for(int i=0; i<n; i++){
-    //         if(y[i] > 0){
-    //             // avoid comparing equality to zero...
-    //             h[i] = exp(pred[i]) / ((exp(pred[i]) + 1.0)*(exp(pred[i]) + 1.0));
-    //         }else{
-    //             // get y[i] == 0
-    //             h[i] = -(exp(lprob_weights[i])-1.0)*exp(pred[i])*(exp(2.0*pred[i])-exp(lprob_weights[i])) / 
-    //                 ( (exp(pred[i])+1.0)*(exp(pred[i])+1.0)*(exp(lprob_weights[i])+exp(pred[i]))*(exp(lprob_weights[i])+exp(pred[i])) );
-    //         }
-    //     }
-    // }else if(loss_type=="negbinom::zinb"){
-    //     // NEGBINOM COND Y>0, LOG LINK
-    //     double dispersion = ens_ptr -> extra_param;
-    //     for(int i=0; i<n; i++){
-    //         h[i] = (y[i]+dispersion)*dispersion*exp(pred[i]) / 
-    //             ( (dispersion + exp(pred[i]))*(dispersion + exp(pred[i])) ) - 
-    //             // d^2/dx^2 log(p(y>0))
-    //             -dispersion*dispersion*exp(pred[i])*
-    //             ((exp(pred[i])-1.0)*exp(dispersion*(log(dispersion+exp(pred[i]))-log(dispersion))) +1.0 ) / 
-    //             (exp(2.0*log(dispersion+exp(pred[i]))) * 
-    //              pow(exp(dispersion*(log(dispersion+exp(pred[i]))-log(dispersion))) - 1.0, 2.0 )  );
-    //     }
-    // }
-    
-    return h;    
 }
 
 

--- a/R-package/src/agtboost.cpp
+++ b/R-package/src/agtboost.cpp
@@ -143,6 +143,22 @@ void verbose_output(int verbose, int iteration, int nleaves, double tr_loss, dou
         }
     }
 }
+
+
+// Loss functions defined in Ensemble class
+double ENSEMBLE::loss(Tvec<double> &y, Tvec<double> &pred, Tvec<double> &w){
+    return loss_functions::loss(y, pred, loss_function, w, extra_param);
+}
+
+
+Tvec<double> ENSEMBLE::dloss(Tvec<double> &y, Tvec<double> &pred){
+    return loss_functions::dloss(y, pred, loss_function, extra_param);
+}
+
+
+Tvec<double> ENSEMBLE::ddloss(Tvec<double> &y, Tvec<double> &pred){
+    return loss_functions::ddloss(y, pred, loss_function, extra_param);
+}
                 
                 
 void ENSEMBLE::train(
@@ -173,11 +189,11 @@ void ENSEMBLE::train(
     }
     pred.setConstant(this->initialPred);
     pred += offset;
-    this->initial_score = loss(y, pred, loss_function, w, extra_param);
+    this->initial_score = loss_functions::loss(y, pred, loss_function, w, extra_param);
     
     // First tree
-    g = dloss(y, pred, loss_function, extra_param) * w;
-    h = ddloss(y, pred, loss_function, extra_param) * w;
+    g = dloss(y, pred) * w;
+    h = ddloss(y, pred) * w;
     this->first_tree = new GBTREE;
     this->first_tree->train(g, h, X, cir_sim, greedy_complexities, learning_rate);
     GBTREE* current_tree = this->first_tree;
@@ -187,7 +203,7 @@ void ENSEMBLE::train(
         verbose,
         1,
         current_tree->getNumLeaves(),
-        loss(y, pred, loss_function, w, extra_param),
+        loss(y, pred, w),
         this->estimate_generalization_loss(1)
     );
     
@@ -197,8 +213,8 @@ void ENSEMBLE::train(
         if (i % 1 == 0)
             Rcpp::checkUserInterrupt();
         // Calculate gradients
-        g = dloss(y, pred, loss_function, extra_param) * w;
-        h = ddloss(y, pred, loss_function, extra_param) * w;
+        g = dloss(y, pred) * w;
+        h = ddloss(y, pred) * w;
         // Check for perfect fit
         if(((g.array())/h.array()).matrix().maxCoeff() < 1e-12){
             // Every perfect step is below tresh
@@ -212,7 +228,7 @@ void ENSEMBLE::train(
         // Calculate expected generalization loss for tree
         expected_loss = tree_expected_test_reduction(new_tree, learning_rate);
         // Update ensemble training loss and ensemble optimism for iteration k-1
-        ensemble_training_loss = loss(y, pred, loss_function, w, extra_param);
+        ensemble_training_loss = loss_functions::loss(y, pred, loss_function, w, extra_param);
         ensemble_approx_training_loss = this->estimate_training_loss(i-1) + 
             new_tree->getTreeScore() * (-2)*learning_rate*(learning_rate/2 - 1);
         ensemble_optimism = this->estimate_optimism(i-1) + 
@@ -253,18 +269,18 @@ void ENSEMBLE::train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double
     Tvec<double> g(n), h(n);
     
     // Initial prediction
-    g = dloss(y, pred, loss_function, extra_param)*w;
-    h = ddloss(y, pred, loss_function, extra_param)*w;
+    g = loss_functions::dloss(y, pred, loss_function, extra_param)*w;
+    h = loss_functions::ddloss(y, pred, loss_function, extra_param)*w;
     this->initialPred = - g.sum() / h.sum();
     pred = pred.array() + this->initialPred;
-    this->initial_score = loss(y, pred, loss_function, w, extra_param); //(y - pred).squaredNorm() / n;
+    this->initial_score = loss_functions::loss(y, pred, loss_function, w, extra_param); //(y - pred).squaredNorm() / n;
     
     // Prepare cir matrix
     Tmat<double> cir_sim = cir_sim_mat(100, 100);
     
     // First tree
-    g = dloss(y, pred, loss_function, extra_param)*w;
-    h = ddloss(y, pred, loss_function, extra_param)*w;
+    g = loss_functions::dloss(y, pred, loss_function, extra_param)*w;
+    h = loss_functions::ddloss(y, pred, loss_function, extra_param)*w;
     this->first_tree = new GBTREE;
     this->first_tree->train(g, h, X, cir_sim, greedy_complexities, learning_rate_set);
     GBTREE* current_tree = this->first_tree;
@@ -277,7 +293,7 @@ void ENSEMBLE::train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double
             std::setprecision(4) <<
                 "it: " << 1 << 
                     "  |  n-leaves: " << current_tree->getNumLeaves() <<
-                        "  |  tr loss: " << loss(y, pred, loss_function, w, extra_param) <<
+                        "  |  tr loss: " << loss_functions::loss(y, pred, loss_function, w, extra_param) <<
                             "  |  gen loss: " << this->estimate_generalization_loss(1) << 
                                 std::endl;
     }
@@ -292,8 +308,8 @@ void ENSEMBLE::train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double
         
         // TRAINING
         GBTREE* new_tree = new GBTREE();
-        g = dloss(y, pred, loss_function, extra_param)*w;
-        h = ddloss(y, pred, loss_function, extra_param)*w;
+        g = loss_functions::dloss(y, pred, loss_function, extra_param)*w;
+        h = loss_functions::ddloss(y, pred, loss_function, extra_param)*w;
         new_tree->train(g, h, X, cir_sim, greedy_complexities, learning_rate_set);
         
         // EXPECTED LOSS
@@ -310,7 +326,7 @@ void ENSEMBLE::train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double
                     std::setprecision(4) <<
                         "it: " << i << 
                             "  |  n-leaves: " << current_tree->getNumLeaves() << 
-                                "  |  tr loss: " << loss(y, pred, loss_function, w, extra_param) <<
+                                "  |  tr loss: " << loss_functions::loss(y, pred, loss_function, w, extra_param) <<
                                     "  |  gen loss: " << this->estimate_generalization_loss(i-1) + expected_loss << 
                                         std::endl;
                 
@@ -504,7 +520,7 @@ Tvec<double> ENSEMBLE::convergence(Tvec<double> &y, Tmat<double> &X){
     w.setOnes();
     
     // After each update (tree), compute loss
-    loss_val[0] = loss(y, pred, this->loss_function, w, extra_param);
+    loss_val[0] = loss_functions::loss(y, pred, this->loss_function, w, extra_param);
     
     GBTREE* current = this->first_tree;
     for(int k=1; k<(K+1); k++)
@@ -513,7 +529,7 @@ Tvec<double> ENSEMBLE::convergence(Tvec<double> &y, Tmat<double> &X){
         pred = pred + (this->learning_rate) * (current->predict_data(X));
         
         // Compute loss
-        loss_val[k] = loss(y, pred, this->loss_function, w, extra_param);
+        loss_val[k] = loss_functions::loss(y, pred, this->loss_function, w, extra_param);
         
         // Update to next tree
         current = current->next_tree;


### PR DESCRIPTION
Create module `initial_prediction.hpp` that solves $\arg\min_\eta \sum_i l(y_i, g^{-1}(offset_i+\eta))$ numerically instead of simple average to obtain initial prediction

- Module should define function `get_initial_prediction(y, offset)`
- Start optimization at simple transformed average
- Module loads definition to obtain `g` and `h`
- Newton optimization defining derivatives as average `g_i` and `h_i`, evaluated at `offset_i+eta`
- Return when close to machine precision `1E-9` is obtained