### PR TITLE
Moved non-linearity check from error to warning

### DIFF
--- a/R-package/src/agtboost.cpp
+++ b/R-package/src/agtboost.cpp
@@ -269,7 +269,7 @@ void ENSEMBLE::train(
         current_tree = new_tree;
         // Check for non-linearity
         if(std::abs(ensemble_training_loss-ensemble_approx_training_loss)>1E-5){
-            Rcpp::warning("Error: Loss-function deviating from gradient boosting approximation. Try smaller learning_rate.");
+            Rcpp::warning("Warning: Loss-function deviating from gradient boosting approximation. Try smaller learning_rate.");
         }
     }
 }

--- a/R-package/src/agtboost.cpp
+++ b/R-package/src/agtboost.cpp
@@ -269,7 +269,7 @@ void ENSEMBLE::train(
         current_tree = new_tree;
         // Check for non-linearity
         if(std::abs(ensemble_training_loss-ensemble_approx_training_loss)>1E-5){
-            Rcpp::stop("Error: Loss-function deviating from gradient boosting approximation. Try smaller learning_rate.");
+            Rcpp::warning("Error: Loss-function deviating from gradient boosting approximation. Try smaller learning_rate.");
         }
     }
 }


### PR DESCRIPTION
This seems a useful change, especially as the non-linearity check always fails if observations are weighted for some problems even at miniscule learning rates.